### PR TITLE
fix(web): /recipients/{id}/secrets returns 400 "Recipient ID is required"

### DIFF
--- a/internal/web/dispatch_path_id_test.go
+++ b/internal/web/dispatch_path_id_test.go
@@ -1,0 +1,77 @@
+package web
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestDispatchPathID(t *testing.T) {
+	cases := []struct {
+		name    string
+		path    string
+		prefix  string
+		wantID  string
+		wantSet bool
+	}{
+		{
+			name:    "recipient edit",
+			path:    "/recipients/abc-123",
+			prefix:  "/recipients/",
+			wantID:  "abc-123",
+			wantSet: true,
+		},
+		{
+			name:    "recipient secrets management",
+			path:    "/recipients/23e36417-16b4-483b-8682-a4528c09d636/secrets",
+			prefix:  "/recipients/",
+			wantID:  "23e36417-16b4-483b-8682-a4528c09d636",
+			wantSet: true,
+		},
+		{
+			name:    "recipient test action",
+			path:    "/recipients/abc-123/test",
+			prefix:  "/recipients/",
+			wantID:  "abc-123",
+			wantSet: true,
+		},
+		{
+			name:    "secret view",
+			path:    "/secrets/sec-1",
+			prefix:  "/secrets/",
+			wantID:  "sec-1",
+			wantSet: true,
+		},
+		{
+			name: "secret assign — id is the first segment, not the last " +
+				"(GetLastURLSegment would have returned 'assign')",
+			path:    "/secrets/sec-1/assign",
+			prefix:  "/secrets/",
+			wantID:  "sec-1",
+			wantSet: true,
+		},
+		{
+			name:    "missing id — bare prefix",
+			path:    "/recipients/",
+			prefix:  "/recipients/",
+			wantID:  "",
+			wantSet: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", tc.path, nil)
+			got := dispatchPathID(req, tc.prefix)
+			if got != tc.wantID {
+				t.Fatalf("dispatchPathID returned %q, want %q", got, tc.wantID)
+			}
+			if got != req.PathValue("id") {
+				t.Fatalf("PathValue(\"id\") = %q, want %q (function returned %q)",
+					req.PathValue("id"), tc.wantID, got)
+			}
+			if tc.wantSet && req.PathValue("id") == "" {
+				t.Fatal("PathValue(\"id\") not set; downstream handlers will respond 400 \"ID is required\"")
+			}
+		})
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -221,9 +221,25 @@ func (s *Server) handleMethodRouter(methods ...interface{}) http.HandlerFunc {
 	}
 }
 
+// dispatchPathID extracts the resource id from the first path segment
+// after a known prefix and exposes it to downstream handlers via
+// r.SetPathValue("id"). The /recipients/ and /secrets/ routes are
+// registered as catch-all patterns (not /recipients/{id}/...), so
+// http.ServeMux does not bind the id automatically — without this,
+// r.PathValue("id") inside the leaf handlers returns "" and they
+// respond 400 "... ID is required".
+func dispatchPathID(r *http.Request, prefix string) string {
+	rest := strings.TrimPrefix(r.URL.Path, prefix)
+	parts := strings.SplitN(rest, "/", 2)
+	if parts[0] == "" {
+		return ""
+	}
+	r.SetPathValue("id", parts[0])
+	return parts[0]
+}
+
 func (s *Server) handleSecrets(w http.ResponseWriter, r *http.Request) {
-	id := utils.GetLastURLSegment(r)
-	if id == "" {
+	if dispatchPathID(r, "/secrets/") == "" {
 		http.NotFound(w, r)
 		return
 	}
@@ -253,18 +269,13 @@ func (s *Server) handleSecrets(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleRecipients(w http.ResponseWriter, r *http.Request) {
-	// Extract the recipient ID from the URL path
-	path := strings.TrimPrefix(r.URL.Path, "/recipients/")
-	parts := strings.Split(path, "/")
-	if len(parts) == 0 || parts[0] == "" {
+	id := dispatchPathID(r, "/recipients/")
+	if id == "" {
 		http.NotFound(w, r)
 		return
 	}
 
-	// The first part is the recipient ID
-	id := parts[0]
-
-	// Set the ID in the request context so handlers can access it
+	// Also expose via the legacy context key for any handler still reading it.
 	r = r.WithContext(context.WithValue(r.Context(), authMiddleware.RecipientIDContextKey, id))
 
 	// Handle test contact request
@@ -312,6 +323,8 @@ func (s *Server) handleConfirmation(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
+	// Expose the code to the handler via r.PathValue("code").
+	r.SetPathValue("code", code)
 	s.handlers.recipients.HandleConfirmRecipient(w, r)
 }
 


### PR DESCRIPTION
## Summary

Pre-existing routing bug surfaced by the Heartbeat redesign now exposing Edit / Test / Letters buttons on the recipients page.

**Repro**: visit `/recipients/<uuid>/secrets`, `/recipients/<uuid>` (edit), or `/recipients/<uuid>/test` → server returns `400 Recipient ID is required`.

**Cause**: the `/recipients/` and `/secrets/` routes are registered as catch-all patterns (not `/recipients/{id}/...`), so `http.ServeMux` doesn't bind the id placeholder. The leaf handlers all read `r.PathValue("id")`, which returns `""`, and short-circuit with the 400.

**Fix**: consolidate id extraction in a `dispatchPathID(r, prefix)` helper that pulls the first segment after the prefix and calls `r.SetPathValue("id", id)` so the existing `r.PathValue("id")` reads in the leaf handlers work.

Two related issues fixed at the same time:
- `handleSecrets` was using `utils.GetLastURLSegment`, which returns `"assign"` for `/secrets/{id}/assign` — wrong even before the heartbeat redesign.
- Confirmation route (`/confirm/{code}`) had the same shape; `HandleConfirmRecipient` reads `r.PathValue("code")`, so we now `SetPathValue("code", code)` there too.

## Test plan

- [x] `go test ./...` passes
- [x] New `TestDispatchPathID` covers: recipient edit, recipient secrets, recipient test, secret view, secret assign (regression for the wrong `GetLastURLSegment` extraction), and bare-prefix `/recipients/`
- [ ] Visit `/recipients/<id>/secrets` on the deployed instance after merge — should render the Manage Letters page, not 400
- [ ] Visit `/recipients/<id>` (Edit) and `/recipients/<id>/test` — same